### PR TITLE
Enhancement/28 bottom navigation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,13 +31,11 @@ jobs:
           channel: 'stable'
       - name: Install app dependencies
         run: flutter pub get
-      - name: Run widget and unit tests
-        run: flutter test test --coverage --coverage-path coverage/lcov.base.info
       - name: Run integration tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
             api-level: 29
-            script: flutter test integration_test --coverage --merge-coverage
+            script: flutter test integration_test --coverage
       - name: Upload coverage to Codecov 
         uses: codecov/codecov-action@v1 
         with: 

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 .pub-cache/
 .pub/
 /build/
+pubspec.lock
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/integration_test/light_list_page_test.dart
+++ b/integration_test/light_list_page_test.dart
@@ -140,7 +140,8 @@ void main() {
         await startApp(tester);
 
         await tester.drag(find.byType(LightListItem).first,
-            Offset(tester.binding.window.physicalSize.width * -0.80, 0));
+            Offset(tester.binding.window.physicalSize.width * -0.80, 0),
+            warnIfMissed: false);
         await tester.pumpAndSettle();
 
         expect(
@@ -159,7 +160,8 @@ void main() {
             tester.widgetList<LightListItem>(find.byType(LightListItem)).length;
 
         await tester.drag(find.byType(LightListItem).first,
-            Offset(tester.binding.window.physicalSize.width * -0.80, 0));
+            Offset(tester.binding.window.physicalSize.width * -0.80, 0),
+            warnIfMissed: false);
         await tester.pumpAndSettle();
 
         await tester.tap(find.text('Cancel'));
@@ -180,7 +182,8 @@ void main() {
             tester.widgetList<LightListItem>(find.byType(LightListItem)).length;
 
         await tester.drag(find.byType(LightListItem).first,
-            Offset(tester.binding.window.physicalSize.width * -0.80, 0));
+            Offset(tester.binding.window.physicalSize.width * -0.80, 0),
+            warnIfMissed: false);
         await tester.pumpAndSettle();
 
         await tester.tap(find.text('Confirm'));

--- a/integration_test/navigation_test.dart
+++ b/integration_test/navigation_test.dart
@@ -12,43 +12,46 @@ import 'utils.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('navigates to light list page', (WidgetTester tester) async {
-    await startApp(tester);
-    await openNavigationDrawer(tester);
+  group('navigation drawer', () {
+    testWidgets('navigates to settings page', (WidgetTester tester) async {
+      await startApp(tester);
+      await openNavigationDrawer(tester);
 
-    await tester.tap(find.byKey(const Key('to LightListPage')));
-    await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('to SettingsPage')));
+      await tester.pumpAndSettle();
 
-    expect(find.byType(LightListPage), findsOneWidget);
+      expect(find.byType(SettingsPage), findsOneWidget);
+    });
+
+    testWidgets('navigates to about page', (WidgetTester tester) async {
+      await startApp(tester);
+      await openNavigationDrawer(tester);
+
+      await tester.tap(find.byKey(const Key('to AboutPage')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AboutPage), findsOneWidget);
+    });
   });
 
-  testWidgets('navigates to smart hub list page', (WidgetTester tester) async {
-    await startApp(tester);
-    await openNavigationDrawer(tester);
+  group('bottom navigation', () {
+    testWidgets('navigates to light list page', (WidgetTester tester) async {
+      await startApp(tester);
 
-    await tester.tap(find.byKey(const Key('to SmartHubListPage')));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('Lights'));
+      await tester.pumpAndSettle();
 
-    expect(find.byType(SmartHubListPage), findsOneWidget);
-  });
+      expect(find.byType(LightListPage), findsOneWidget);
+    });
 
-  testWidgets('navigates to settings page', (WidgetTester tester) async {
-    await startApp(tester);
-    await openNavigationDrawer(tester);
+    testWidgets('navigates to smart hub list page',
+        (WidgetTester tester) async {
+      await startApp(tester);
 
-    await tester.tap(find.byKey(const Key('to SettingsPage')));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('Smart Hubs'));
+      await tester.pumpAndSettle();
 
-    expect(find.byType(SettingsPage), findsOneWidget);
-  });
-
-  testWidgets('navigates to about page', (WidgetTester tester) async {
-    await startApp(tester);
-    await openNavigationDrawer(tester);
-
-    await tester.tap(find.byKey(const Key('to AboutPage')));
-    await tester.pumpAndSettle();
-
-    expect(find.byType(AboutPage), findsOneWidget);
+      expect(find.byType(SmartHubListPage), findsOneWidget);
+    });
   });
 }

--- a/integration_test/utils.dart
+++ b/integration_test/utils.dart
@@ -52,12 +52,7 @@ Future navigateToSettingsPage(WidgetTester tester) async {
 }
 
 Future navigateToSmartHubListPage(WidgetTester tester) async {
-  await tester.tap(find
-      .descendant(
-        of: find.byType(AppBar),
-        matching: find.byType(IconButton),
-      )
-      .first);
+  await tester.tap(find.text('Smart Hubs'));
   await tester.pumpAndSettle();
 
   await tester.tap(find.byKey(const Key('to SmartHubListPage')));

--- a/lib/interfaces/tab_page.dart
+++ b/lib/interfaces/tab_page.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+abstract class TabPage {
+  String get title;
+  String get tabBarText;
+  IconData get tabBarIcon;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:smart_home_control/views/pages/light_add_page.dart';
 import 'package:smart_home_control/views/pages/light_edit_page.dart';
 
+import 'package:smart_home_control/views/pages/page.dart';
 import 'package:smart_home_control/views/pages/about_page.dart';
 import 'package:smart_home_control/views/pages/light_list_page.dart';
 import 'package:smart_home_control/views/pages/settings_page.dart';
@@ -13,8 +14,54 @@ void main() {
   runApp(const SmartHomeControlApp());
 }
 
-class SmartHomeControlApp extends StatelessWidget {
+class SmartHomeControlApp extends StatefulWidget {
   const SmartHomeControlApp({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _SmartHomeControlAppState();
+}
+
+class _SmartHomeControlAppState extends State<SmartHomeControlApp> {
+  static const List<Widget> _widgetOptions = <Widget>[
+    LightListPage(),
+    SmartHubListPage(),
+    SettingsPage(),
+    AboutPage()
+  ];
+
+  static final List<BottomNavigationBarItem> _tabButtons = _widgetOptions
+      .map((e) => BottomNavigationBarItem(
+          icon: Icon((e as TabPage).navigationIcon),
+          label: (e as TabPage).title))
+      .toList();
+
+  int _selectedIndex = 0;
+
+  void _onNavigationTabTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  TabPage _getCurrentPage() {
+    return _widgetOptions.elementAt(_selectedIndex) as TabPage;
+  }
+
+  FloatingActionButton? _getFloatingActionButton() {
+    TabPage currentPage = _getCurrentPage();
+
+    IconData? icon = currentPage.floatingActionButtonIcon;
+    Function()? tapCallback = currentPage.floatingActionButtonPressedCallback;
+
+    if (icon != null && tapCallback != null) {
+      return FloatingActionButton(
+        onPressed: tapCallback,
+        child: Icon(icon),
+      );
+    }
+
+    return null;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,14 +70,22 @@ class SmartHomeControlApp extends StatelessWidget {
         theme: ThemeData.light(),
         darkTheme: ThemeData.dark(),
         themeMode: ThemeMode.system,
-        home: const LightListPage(),
+        home: Scaffold(
+          appBar: AppBar(
+            title: Text(
+                (_widgetOptions.elementAt(_selectedIndex) as TabPage).title),
+          ),
+          body: _widgetOptions.elementAt(_selectedIndex),
+          bottomNavigationBar: BottomNavigationBar(
+            items: _tabButtons,
+            currentIndex: _selectedIndex,
+            onTap: _onNavigationTabTapped,
+          ),
+          floatingActionButton: _getFloatingActionButton(),
+        ),
         routes: {
-          Routes.lights: (context) => const LightListPage(),
           Routes.lightsNew: (context) => const LightAddPage(),
           Routes.lightsEdit: (context) => const LightEditPage(),
-          Routes.smartHubs: (context) => const SmartHubListPage(),
-          Routes.settings: (context) => const SettingsPage(),
-          Routes.about: (context) => const AboutPage(),
         });
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:smart_home_control/views/components/navigation_drawer.dart';
 import 'package:smart_home_control/views/pages/light_add_page.dart';
 import 'package:smart_home_control/views/pages/light_edit_page.dart';
 
-import 'package:smart_home_control/views/pages/page.dart';
 import 'package:smart_home_control/views/pages/about_page.dart';
 import 'package:smart_home_control/views/pages/light_list_page.dart';
 import 'package:smart_home_control/views/pages/settings_page.dart';
 import 'package:smart_home_control/views/pages/smart_hub_list_page.dart';
+import 'package:smart_home_control/interfaces/tab_page.dart';
 
 import 'routes/routes.dart';
 
@@ -21,46 +22,26 @@ class SmartHomeControlApp extends StatefulWidget {
   State<StatefulWidget> createState() => _SmartHomeControlAppState();
 }
 
-class _SmartHomeControlAppState extends State<SmartHomeControlApp> {
+class _SmartHomeControlAppState extends State<SmartHomeControlApp>
+    with TickerProviderStateMixin {
   static const List<Widget> _widgetOptions = <Widget>[
     LightListPage(),
-    SmartHubListPage(),
-    SettingsPage(),
-    AboutPage()
+    SmartHubListPage()
   ];
 
-  static final List<BottomNavigationBarItem> _tabButtons = _widgetOptions
-      .map((e) => BottomNavigationBarItem(
-          icon: Icon((e as TabPage).navigationIcon),
-          label: (e as TabPage).title))
-      .toList();
+  late TabController _tabController;
 
-  int _selectedIndex = 0;
+  @override
+  void initState() {
+    super.initState();
 
-  void _onNavigationTabTapped(int index) {
-    setState(() {
-      _selectedIndex = index;
-    });
+    _tabController = TabController(length: _widgetOptions.length, vsync: this);
   }
 
-  TabPage _getCurrentPage() {
-    return _widgetOptions.elementAt(_selectedIndex) as TabPage;
-  }
-
-  FloatingActionButton? _getFloatingActionButton() {
-    TabPage currentPage = _getCurrentPage();
-
-    IconData? icon = currentPage.floatingActionButtonIcon;
-    Function()? tapCallback = currentPage.floatingActionButtonPressedCallback;
-
-    if (icon != null && tapCallback != null) {
-      return FloatingActionButton(
-        onPressed: tapCallback,
-        child: Icon(icon),
-      );
-    }
-
-    return null;
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
   }
 
   @override
@@ -71,21 +52,40 @@ class _SmartHomeControlAppState extends State<SmartHomeControlApp> {
         darkTheme: ThemeData.dark(),
         themeMode: ThemeMode.system,
         home: Scaffold(
-          appBar: AppBar(
-            title: Text(
-                (_widgetOptions.elementAt(_selectedIndex) as TabPage).title),
-          ),
-          body: _widgetOptions.elementAt(_selectedIndex),
-          bottomNavigationBar: BottomNavigationBar(
-            items: _tabButtons,
-            currentIndex: _selectedIndex,
-            onTap: _onNavigationTabTapped,
-          ),
-          floatingActionButton: _getFloatingActionButton(),
-        ),
+            appBar: AppBar(
+              centerTitle: true,
+              title: const Text('Smart Home Control'),
+            ),
+            body: TabBarView(
+              controller: _tabController,
+              children: _widgetOptions.map((e) => Container(child: e)).toList(),
+            ),
+            drawer: const NavigationDrawer(),
+            bottomNavigationBar: BottomAppBar(
+              child: SizedBox(
+                height: 50,
+                child: _buildTabBar(),
+              ),
+            )),
         routes: {
           Routes.lightsNew: (context) => const LightAddPage(),
           Routes.lightsEdit: (context) => const LightEditPage(),
+          Routes.settings: (context) => const SettingsPage(),
+          Routes.about: (context) => const AboutPage()
         });
+  }
+
+  TabBar _buildTabBar() {
+    return TabBar(
+        controller: _tabController,
+        tabs: _widgetOptions
+            .map((e) => Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon((e as TabPage).tabBarIcon),
+                    Text((e as TabPage).tabBarText)
+                  ],
+                ))
+            .toList());
   }
 }

--- a/lib/views/components/navigation_drawer.dart
+++ b/lib/views/components/navigation_drawer.dart
@@ -8,53 +8,28 @@ class NavigationDrawer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Drawer(
-        child: Column(
+        child: ListView(
+      padding: EdgeInsets.zero,
       children: [
-        SizedBox(
-          height: 150,
-          child: DrawerHeader(
+        DrawerHeader(
             decoration:
                 BoxDecoration(color: Theme.of(context).colorScheme.secondary),
-            child: null,
-          ),
+            child: Text('Smart Home Control',
+                style: TextStyle(
+                    fontSize: 24,
+                    color: Theme.of(context).colorScheme.onSecondary))),
+        ListTile(
+          key: const Key('to SettingsPage'),
+          leading: const Icon(Icons.settings),
+          title: const Text('Settings'),
+          onTap: () => Navigator.pushNamed(context, Routes.settings),
         ),
-        Expanded(
-          child: ListView(
-            itemExtent: 40,
-            padding: EdgeInsets.zero,
-            children: [
-              ListTile(
-                key: const Key('to LightListPage'),
-                leading: const Icon(Icons.lightbulb),
-                title: const Text('Lights'),
-                onTap: () =>
-                    Navigator.pushReplacementNamed(context, Routes.lights),
-              ),
-              ListTile(
-                key: const Key('to SmartHubListPage'),
-                leading: const Icon(Icons.device_hub),
-                title: const Text('Smart Hubs'),
-                onTap: () =>
-                    Navigator.pushReplacementNamed(context, Routes.smartHubs),
-              ),
-              const Divider(),
-              ListTile(
-                key: const Key('to SettingsPage'),
-                leading: const Icon(Icons.settings),
-                title: const Text('Settings'),
-                onTap: () =>
-                    Navigator.pushReplacementNamed(context, Routes.settings),
-              ),
-              ListTile(
-                key: const Key('to AboutPage'),
-                leading: const Icon(Icons.info),
-                title: const Text('About'),
-                onTap: () =>
-                    Navigator.pushReplacementNamed(context, Routes.about),
-              ),
-            ],
-          ),
-        )
+        ListTile(
+          key: const Key('to AboutPage'),
+          leading: const Icon(Icons.info),
+          title: const Text('About'),
+          onTap: () => Navigator.pushNamed(context, Routes.about),
+        ),
       ],
     ));
   }

--- a/lib/views/forms/settings_form.dart
+++ b/lib/views/forms/settings_form.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:smart_home_control/models/settings.dart';
 import 'package:smart_home_control/views/forms/form_with_submit_trigger.dart';

--- a/lib/views/pages/about_page.dart
+++ b/lib/views/pages/about_page.dart
@@ -1,23 +1,29 @@
 import 'package:flutter/material.dart';
 
-import 'package:smart_home_control/views/components/navigation_drawer.dart';
+import 'package:smart_home_control/views/pages/page.dart';
 
-class AboutPage extends StatefulWidget {
+class AboutPage extends StatefulWidget implements TabPage {
   const AboutPage({Key? key}) : super(key: key);
 
   @override
   State<AboutPage> createState() => _AboutPageState();
+
+  @override
+  String get title => 'About';
+
+  @override
+  IconData? get floatingActionButtonIcon => null;
+
+  @override
+  Function()? get floatingActionButtonPressedCallback => null;
+
+  @override
+  IconData get navigationIcon => Icons.info;
 }
 
 class _AboutPageState extends State<AboutPage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('About'),
-      ),
-      body: const Center(child: Text('Here goes some text about this app')),
-      drawer: const NavigationDrawer(),
-    );
+    return const Center(child: Text('Here goes some text about this app'));
   }
 }

--- a/lib/views/pages/about_page.dart
+++ b/lib/views/pages/about_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'package:smart_home_control/views/pages/page.dart';
+import 'package:smart_home_control/interfaces/tab_page.dart';
 
 class AboutPage extends StatefulWidget implements TabPage {
   const AboutPage({Key? key}) : super(key: key);
@@ -12,18 +12,21 @@ class AboutPage extends StatefulWidget implements TabPage {
   String get title => 'About';
 
   @override
-  IconData? get floatingActionButtonIcon => null;
+  IconData get tabBarIcon => Icons.info;
 
   @override
-  Function()? get floatingActionButtonPressedCallback => null;
-
-  @override
-  IconData get navigationIcon => Icons.info;
+  String get tabBarText => 'About';
 }
 
 class _AboutPageState extends State<AboutPage> {
   @override
   Widget build(BuildContext context) {
-    return const Center(child: Text('Here goes some text about this app'));
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: const Text('About'),
+      ),
+      body: const Center(child: Text('Here goes some text about this app')),
+    );
   }
 }

--- a/lib/views/pages/light_list_page.dart
+++ b/lib/views/pages/light_list_page.dart
@@ -7,12 +7,27 @@ import 'package:smart_home_control/models/settings.dart';
 import 'package:smart_home_control/routes/routes.dart';
 import 'package:smart_home_control/views/components/light_list_item.dart';
 import 'package:smart_home_control/views/components/navigation_drawer.dart';
+import 'package:smart_home_control/views/pages/tab_page.dart';
 
-class LightListPage extends StatefulWidget {
+class LightListPage extends StatefulWidget implements TabPage {
   const LightListPage({Key? key}) : super(key: key);
 
   @override
   State<LightListPage> createState() => _LightListPageState();
+
+  @override
+  String get title => 'Lights';
+
+  @override
+  IconData? get floatingActionButtonIcon => Icons.add;
+
+  @override
+  // TODO: implement floatingActionButtonPressedCallback
+  Function()? get floatingActionButtonPressedCallback =>
+      throw UnimplementedError();
+
+  @override
+  IconData get navigationIcon => Icons.lightbulb;
 }
 
 class _LightListPageState extends State<LightListPage> {
@@ -23,9 +38,6 @@ class _LightListPageState extends State<LightListPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Lights'),
-        ),
         body: FutureBuilder<List<LightStrip>>(
             future: DatabaseHelper.instance.getAllLightStrips(),
             builder: buildLightStripListFromSnapshot),

--- a/lib/views/pages/light_list_page.dart
+++ b/lib/views/pages/light_list_page.dart
@@ -6,8 +6,7 @@ import 'package:smart_home_control/models/settings.dart';
 
 import 'package:smart_home_control/routes/routes.dart';
 import 'package:smart_home_control/views/components/light_list_item.dart';
-import 'package:smart_home_control/views/components/navigation_drawer.dart';
-import 'package:smart_home_control/views/pages/tab_page.dart';
+import 'package:smart_home_control/interfaces/tab_page.dart';
 
 class LightListPage extends StatefulWidget implements TabPage {
   const LightListPage({Key? key}) : super(key: key);
@@ -19,15 +18,10 @@ class LightListPage extends StatefulWidget implements TabPage {
   String get title => 'Lights';
 
   @override
-  IconData? get floatingActionButtonIcon => Icons.add;
+  IconData get tabBarIcon => Icons.lightbulb;
 
   @override
-  // TODO: implement floatingActionButtonPressedCallback
-  Function()? get floatingActionButtonPressedCallback =>
-      throw UnimplementedError();
-
-  @override
-  IconData get navigationIcon => Icons.lightbulb;
+  String get tabBarText => 'Lights';
 }
 
 class _LightListPageState extends State<LightListPage> {
@@ -41,7 +35,6 @@ class _LightListPageState extends State<LightListPage> {
         body: FutureBuilder<List<LightStrip>>(
             future: DatabaseHelper.instance.getAllLightStrips(),
             builder: buildLightStripListFromSnapshot),
-        drawer: const NavigationDrawer(),
         floatingActionButton: FloatingActionButton(
           onPressed: () => Navigator.pushNamed(context, Routes.lightsNew)
               .then((_) => setState(() {})),

--- a/lib/views/pages/settings_page.dart
+++ b/lib/views/pages/settings_page.dart
@@ -4,12 +4,29 @@ import 'package:flutter/material.dart';
 
 import 'package:smart_home_control/views/components/navigation_drawer.dart';
 import 'package:smart_home_control/views/forms/settings_form.dart';
+import 'package:smart_home_control/views/pages/page.dart';
 
-class SettingsPage extends StatefulWidget {
+class SettingsPage extends StatefulWidget implements TabPage {
   const SettingsPage({Key? key}) : super(key: key);
 
   @override
   State<SettingsPage> createState() => _SettingsPageState();
+
+  @override
+  String get title => 'Settings';
+
+  @override
+  IconData? get floatingActionButtonIcon => Icons.check;
+
+  @override
+  // TODO: implement
+  Function()? get floatingActionButtonPressedCallback => () {
+        // TODO: find out how to call this on the state:
+        // submitTrigger.sink.add(null)
+      };
+
+  @override
+  IconData get navigationIcon => Icons.settings;
 }
 
 class _SettingsPageState extends State<SettingsPage> {
@@ -17,17 +34,8 @@ class _SettingsPageState extends State<SettingsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Settings'),
-      ),
-      body: SettingsForm(
-        submitTrigger: submitTrigger.stream,
-      ),
-      drawer: const NavigationDrawer(),
-      floatingActionButton: FloatingActionButton(
-          onPressed: () => submitTrigger.sink.add(null),
-          child: const Icon(Icons.check)),
+    return SettingsForm(
+      submitTrigger: submitTrigger.stream,
     );
   }
 }

--- a/lib/views/pages/settings_page.dart
+++ b/lib/views/pages/settings_page.dart
@@ -2,31 +2,13 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
-import 'package:smart_home_control/views/components/navigation_drawer.dart';
 import 'package:smart_home_control/views/forms/settings_form.dart';
-import 'package:smart_home_control/views/pages/page.dart';
 
-class SettingsPage extends StatefulWidget implements TabPage {
+class SettingsPage extends StatefulWidget {
   const SettingsPage({Key? key}) : super(key: key);
 
   @override
   State<SettingsPage> createState() => _SettingsPageState();
-
-  @override
-  String get title => 'Settings';
-
-  @override
-  IconData? get floatingActionButtonIcon => Icons.check;
-
-  @override
-  // TODO: implement
-  Function()? get floatingActionButtonPressedCallback => () {
-        // TODO: find out how to call this on the state:
-        // submitTrigger.sink.add(null)
-      };
-
-  @override
-  IconData get navigationIcon => Icons.settings;
 }
 
 class _SettingsPageState extends State<SettingsPage> {
@@ -34,8 +16,16 @@ class _SettingsPageState extends State<SettingsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return SettingsForm(
-      submitTrigger: submitTrigger.stream,
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: const Text('Settings'),
+      ),
+      body: SettingsForm(submitTrigger: submitTrigger.stream),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => submitTrigger.sink.add(null),
+        child: const Icon(Icons.check),
+      ),
     );
   }
 }

--- a/lib/views/pages/smart_hub_list_page.dart
+++ b/lib/views/pages/smart_hub_list_page.dart
@@ -1,25 +1,31 @@
 import 'package:flutter/material.dart';
 
-import 'package:smart_home_control/views/components/navigation_drawer.dart';
+import 'package:smart_home_control/views/pages/page.dart';
 
-class SmartHubListPage extends StatefulWidget {
+class SmartHubListPage extends StatefulWidget implements TabPage {
   const SmartHubListPage({Key? key}) : super(key: key);
 
   @override
   State<SmartHubListPage> createState() => _SmartHubListPageState();
+
+  @override
+  String get title => 'Smart Hubs';
+
+  @override
+  IconData? get floatingActionButtonIcon => null;
+
+  @override
+  Function()? get floatingActionButtonPressedCallback => null;
+
+  @override
+  IconData get navigationIcon => Icons.device_hub;
 }
 
 class _SmartHubListPageState extends State<SmartHubListPage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Smart Hubs'),
-      ),
-      body: const Center(
-          child: Text(
-              'Here goes a list of added smart hubs and a fab to add a new one')),
-      drawer: const NavigationDrawer(),
-    );
+    return const Center(
+        child: Text(
+            'Here goes a list of added smart hubs and a fab to add a new one'));
   }
 }

--- a/lib/views/pages/smart_hub_list_page.dart
+++ b/lib/views/pages/smart_hub_list_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'package:smart_home_control/views/pages/page.dart';
+import 'package:smart_home_control/interfaces/tab_page.dart';
 
 class SmartHubListPage extends StatefulWidget implements TabPage {
   const SmartHubListPage({Key? key}) : super(key: key);
@@ -12,13 +12,10 @@ class SmartHubListPage extends StatefulWidget implements TabPage {
   String get title => 'Smart Hubs';
 
   @override
-  IconData? get floatingActionButtonIcon => null;
+  IconData get tabBarIcon => Icons.device_hub;
 
   @override
-  Function()? get floatingActionButtonPressedCallback => null;
-
-  @override
-  IconData get navigationIcon => Icons.device_hub;
+  String get tabBarText => 'Smart Hubs';
 }
 
 class _SmartHubListPageState extends State<SmartHubListPage> {

--- a/lib/views/pages/tab_page.dart
+++ b/lib/views/pages/tab_page.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+abstract class TabPage {
+  String get title;
+  IconData get navigationIcon;
+  IconData? get floatingActionButtonIcon;
+  Function()? get floatingActionButtonPressedCallback;
+}

--- a/lib/views/pages/tab_page.dart
+++ b/lib/views/pages/tab_page.dart
@@ -1,8 +1,0 @@
-import 'package:flutter/material.dart';
-
-abstract class TabPage {
-  String get title;
-  IconData get navigationIcon;
-  IconData? get floatingActionButtonIcon;
-  Function()? get floatingActionButtonPressedCallback;
-}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -325,13 +325,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
-  material_color_utilities:
-    dependency: transitive
-    description:
-      name: material_color_utilities
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -373,7 +366,7 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.0.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -476,7 +469,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -497,7 +490,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.5.0"
+    version: "7.3.0"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
Closes #28 

## Changes

- adds a bottom navigation bar to navigate to the light list and the smart hub list
- adds an interface for pages that can be displayed in a tab
- adapts tests to the bottom navigation
- removes the widget and unit tests from the ci as there currently aren't any

## Screenshots

![photo_2022-04-06_23-05-19](https://user-images.githubusercontent.com/40767277/162070856-67f8bbfe-354b-4782-a896-85382375bc05.jpg)
![photo_2022-04-06_23-05-08](https://user-images.githubusercontent.com/40767277/162070864-b5c75a5a-b917-408d-b7c7-368fe67a4bcd.jpg)
![photo_2022-04-06_23-05-29](https://user-images.githubusercontent.com/40767277/162070988-8966982e-94d4-4045-ac53-497d2224d4e3.jpg)
![photo_2022-04-06_23-05-23](https://user-images.githubusercontent.com/40767277/162070992-4f3983ae-a171-4579-9b24-c3c252914724.jpg)

## Checklist before merge

**Developer's responsibilities**
* [x] **Pull request build** has passed
* [x] **tested locally**
* [x] added **tests** where necessary
